### PR TITLE
[Phase 0] Add local server scripts for .htmd preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,28 @@ HTMD-->
 
 `.htmd` — browsers treat it as HTML (with proper content-type), and AI tooling recognizes the dual-layer convention.
 
+## Quick Start
+
+`.htmd` files must be served over HTTP to render correctly — browsers display them as plain text when opened via `file://`.
+
+### Python (port 8000)
+
+```bash
+python3 tools/serve.py
+```
+
+Then open [http://localhost:8000/examples/hello.htmd](http://localhost:8000/examples/hello.htmd).
+
+### Node.js (port 3000)
+
+```bash
+node tools/serve.js
+```
+
+Then open [http://localhost:3000/examples/hello.htmd](http://localhost:3000/examples/hello.htmd).
+
+Both servers serve `.htmd` files with `Content-Type: text/html` so your browser renders them as HTML.
+
 ## Project Status
 
 This project is in the **specification phase**. See [SPEC.md](SPEC.md) for the format specification.

--- a/tools/serve.js
+++ b/tools/serve.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+"use strict";
+
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+
+const PORT = process.argv[2] ? parseInt(process.argv[2]) : 3000;
+const ROOT = path.resolve(__dirname, "..");
+
+const MIME = {
+  ".htmd": "text/html; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css",
+  ".js": "application/javascript",
+  ".json": "application/json",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".svg": "image/svg+xml",
+};
+
+const server = http.createServer((req, res) => {
+  let urlPath = req.url.split("?")[0];
+  if (urlPath === "/") urlPath = "/index.htmd";
+
+  const filePath = path.join(ROOT, urlPath);
+
+  // Prevent path traversal
+  if (!filePath.startsWith(ROOT)) {
+    res.writeHead(403);
+    res.end("Forbidden");
+    return;
+  }
+
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end(`Not found: ${urlPath}`);
+      return;
+    }
+
+    const ext = path.extname(filePath);
+    const contentType = MIME[ext] || "application/octet-stream";
+    res.writeHead(200, { "Content-Type": contentType });
+    res.end(data);
+    console.log(`  ${req.method} ${urlPath} -> 200`);
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`HTMD server running at http://localhost:${PORT}`);
+  console.log(`Serving files from: ${ROOT}`);
+  console.log("Press Ctrl+C to stop.");
+});

--- a/tools/serve.py
+++ b/tools/serve.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Local server for previewing .htmd files with correct Content-Type."""
+
+import http.server
+import os
+import sys
+
+
+class HTMDHandler(http.server.SimpleHTTPRequestHandler):
+    def guess_type(self, path):
+        if path.endswith(".htmd"):
+            return "text/html; charset=utf-8"
+        return super().guess_type(path)
+
+    def log_message(self, format, *args):
+        print(f"  {self.address_string()} - {format % args}")
+
+
+def main():
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8000
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    os.chdir(root)
+
+    with http.server.HTTPServer(("", port), HTMDHandler) as server:
+        print(f"HTMD server running at http://localhost:{port}")
+        print(f"Serving files from: {root}")
+        print("Press Ctrl+C to stop.")
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print("\nServer stopped.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #1

## Changes

- `tools/serve.py` — Python local server, serves `.htmd` as `text/html`
- `tools/serve.js` — Node.js local server with path traversal protection
- `README.md` — Added Quick Start section with usage instructions

## Review Notes

- Both servers auto-detect project root and serve from there
- Python server uses port 8000, Node.js uses port 3000 (both configurable via CLI arg)
- Node.js version includes path traversal defense and broader MIME type mapping